### PR TITLE
Remove step to install chrome from workflows

### DIFF
--- a/.github/workflows/fast_track.yml
+++ b/.github/workflows/fast_track.yml
@@ -11,10 +11,6 @@ jobs:
     steps:
       - name: checkout repo main
         uses: actions/checkout@v2 # checkout the repository content to github runner.
-      - name: Install Google Chrome # Using shell script to install Google Chrome
-        run: |
-          chmod +x ./scripts/InstallChrome.sh
-          ./scripts/InstallChrome.sh
       - name: setup python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/fast_track_check.yml
+++ b/.github/workflows/fast_track_check.yml
@@ -11,10 +11,6 @@ jobs:
     steps:
       - name: checkout repo main
         uses: actions/checkout@v2 # checkout the repository content to github runner.
-      - name: Install Google Chrome # Using shell script to install Google Chrome
-        run: |
-          chmod +x ./scripts/InstallChrome.sh
-          ./scripts/InstallChrome.sh
       - name: setup python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/premium.yml
+++ b/.github/workflows/premium.yml
@@ -11,10 +11,6 @@ jobs:
     steps:
       - name: checkout repo main
         uses: actions/checkout@v2 # checkout the repository content to github runner.
-      - name: Install Google Chrome # Using shell script to install Google Chrome
-        run: |
-          chmod +x ./scripts/InstallChrome.sh
-          ./scripts/InstallChrome.sh
       - name: setup python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/premium_check.yml
+++ b/.github/workflows/premium_check.yml
@@ -11,10 +11,6 @@ jobs:
     steps:
       - name: checkout repo main
         uses: actions/checkout@v2 # checkout the repository content to github runner.
-      - name: Install Google Chrome # Using shell script to install Google Chrome
-        run: |
-          chmod +x ./scripts/InstallChrome.sh
-          ./scripts/InstallChrome.sh
       - name: setup python
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
Removed installation of Google Chrome step from GitHub action workflows. This step was required for the old selenium method but is no longer needed for the new method. It's removal would increase the speed of the runtime.